### PR TITLE
fix type of arguments to `fillBuffer`

### DIFF
--- a/src/normalize.nim
+++ b/src/normalize.nim
@@ -640,7 +640,7 @@ proc cmpNfd*(a, b: openArray[char]): bool =
     ni, di: var int,
     r: var Rune,
     buff, cccs, dcps: var Buffer,
-    cp, ccc: var int
+    cp, ccc: var int32
   ) =
     ## This is meant to be called and
     ## resumed later with a partially


### PR DESCRIPTION
`fillBuffer`'s last 2 arguments have type `var int`, but it is called later with variables of type `int32`. This is supposed to give a compilation error but doesn't due to Nim bugs.